### PR TITLE
Py3.12+

### DIFF
--- a/cppimport/build_module.py
+++ b/cppimport/build_module.py
@@ -4,12 +4,17 @@ import logging
 import os
 import shutil
 import tempfile
+import sys
 
 import setuptools
 import setuptools.command.build_ext
 
-import distutils
-import distutils.sysconfig
+if sys.version_info[0] >=3 and sys.version_info[1] > 11:
+    import setuptools._distutils as distutils
+    import setuptools._distutils.sysconfig as distutils_sysconfig
+else:
+    import distutils
+    import distutils.sysconfig as distutils_sysconfig
 
 import cppimport
 from cppimport.filepaths import make_absolute
@@ -96,7 +101,7 @@ def _handle_strict_prototypes():
     if not cppimport.settings["remove_strict_prototypes"]:
         return
 
-    cfg_vars = distutils.sysconfig.get_config_vars()
+    cfg_vars = distutils_sysconfig.get_config_vars()
     for key, value in cfg_vars.items():
         if value is str:
             cfg_vars[key] = value.replace("-Wstrict-prototypes", "")

--- a/environment.yml
+++ b/environment.yml
@@ -12,3 +12,4 @@ dependencies:
   - pytest-cov
   - pre-commit
   - filelock
+  - setuptools

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     use_scm_version={"version_scheme": "post-release"},
     setup_requires=["setuptools_scm"],
     packages=["cppimport"],
-    install_requires=["mako", "pybind11", "filelock"],
+    install_requires=["mako", "pybind11", "filelock", "setuptools"],
     zip_safe=False,
     name="cppimport",
     description="Import C++ files directly from Python!",


### PR DESCRIPTION
Python 3.12 removed distutils. Setuptools is a current alternative.
Setuptools contains undocumented submodule _distutils for backward compatibility.
This hotfix uses distutils if run on Python 3.11 and older and setuptools._distutils otherwise.